### PR TITLE
Remove deprecation warnings for show_guide.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: treemapify
 Title: Draw treemaps easily
-Version: 0.2
+Version: 0.2.1
 Author: David Wilkins <contact@wilkox.org>
 Maintainer: David Wilkins <contact@wilkox.org>
 URL: https://github.com/wilkox/treemapify

--- a/R/ggplotify.R
+++ b/R/ggplotify.R
@@ -184,8 +184,7 @@ ggplotify <- function(
       alpha = groupLabels$alpha,
       fontface = "bold",
       hjust = 0.5,
-      vjust = 0,
-      show_guide = FALSE
+      vjust = 0
     )
   }
 
@@ -229,7 +228,7 @@ ggplotify <- function(
       y = labely,
       size = labelsize,
       alpha = alpha
-    ), hjust = 0, vjust = 1, colour = label.colour, show_guide = FALSE)
+    ), hjust = 0, vjust = 1, colour = label.colour, show.legend = FALSE)
 
     # Scale labels, unless label.size.fixed was specified
     if (missing(label.size.fixed)) {


### PR DESCRIPTION
Replaced show_guide with show.legend, also removed a reference to show_guide in the annotate call as it does not appear to be an argument: http://docs.ggplot2.org/current/annotate.html, and further auto defaults to false.